### PR TITLE
NotDeletableViewSet Mixin Order reworked

### DIFF
--- a/sourandperky/apps/api/views/common.py
+++ b/sourandperky/apps/api/views/common.py
@@ -13,5 +13,5 @@ class UpdateRetrieveListViewSet(*UpdateRetrieveListBases):
     ...
 
 
-class NotDeletableViewSet(UpdateRetrieveListViewSet, mixins.CreateModelMixin):
+class NotDeletableViewSet(mixins.CreateModelMixin, UpdateRetrieveListViewSet):
     ...


### PR DESCRIPTION
recommended rules of inheritance provided by Kenneth Love. The rules follow Python’s method resolution order 
1.The base view classes provided by Django always go to the right. 
2 Mixins go to the left of the base view. 
3 Mixins should inherit from Python’s built-in object type